### PR TITLE
Merge AdSize mapping changes 

### DIFF
--- a/ThirdPartyAdapters/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/build.gradle
@@ -15,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { url 'https://jitpack.io' }
         google()
         jcenter()
     }

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     if (gradle.ext.has('dependOnVungleSdkProject') && gradle.ext.dependOnVungleSdkProject) {
         implementation project(':vungle-android-sdk:publisher-sdk-android')
     } else {
-        implementation ('com.github.vungle:vungle-android-sdk:6.5.2-RC3') {
+        implementation ('com.github.vungle:vungle-android-sdk:6.5.2-RC4') {
         //implementation ('com.vungle:publisher-sdk-android:6.5.1') {
             transitive=true
         }

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "6.5.1.0"
+    stringVersion = "6.5.2.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -23,7 +23,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 28
-        versionCode 6050100
+        versionCode 6050200
         versionName stringVersion
 
     }
@@ -36,8 +36,13 @@ android {
 }
 
 dependencies {
-    implementation ('com.vungle:publisher-sdk-android:6.5.1') {
-        transitive=true
+    if (gradle.ext.has('dependOnVungleSdkProject') && gradle.ext.dependOnVungleSdkProject) {
+        implementation project(':vungle-android-sdk:publisher-sdk-android')
+    } else {
+        implementation ('com.github.vungle:vungle-android-sdk:6.5.2-RC3') {
+        //implementation ('com.vungle:publisher-sdk-android:6.5.1') {
+            transitive=true
+        }
     }
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-ads:18.2.0'

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -260,6 +260,11 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         }
 
         adLayout = new RelativeLayout(context);
+        // Make adLayout wrapper match the requested ad size, as Vungle's ad uses MATCH_PARENT for
+        // its dimensions.
+        RelativeLayout.LayoutParams adViewLayoutParams = new RelativeLayout.LayoutParams(
+                adSize.getWidthInPixels(context), adSize.getHeightInPixels(context));
+        adLayout.setLayoutParams(adViewLayoutParams);
         VungleInitializer.getInstance().initialize(config.getAppId(),
                 context.getApplicationContext(),
                 new VungleInitializer.VungleInitializationListener() {
@@ -342,10 +347,14 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
             return;
 
         mVungleManager.cleanUpBanner(mPlacementForPlay);
+        RelativeLayout.LayoutParams adParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.WRAP_CONTENT,
+                RelativeLayout.LayoutParams.WRAP_CONTENT);
+        adParams.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
         if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
             vungleBannerAd = mVungleManager.getVungleBanner(mPlacementForPlay, mAdConfig.getAdSize(), mVunglePlayListener);
             if (vungleBannerAd != null) {
                 updateVisibility();
+                vungleBannerAd.setLayoutParams(adParams);
                 adLayout.addView(vungleBannerAd);
                 if (mMediationBannerListener != null) {
                     mMediationBannerListener.onAdLoaded(VungleInterstitialAdapter.this);
@@ -362,6 +371,7 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
             View adView = vungleNativeAd != null ? vungleNativeAd.renderNativeView() : null;
             if (adView != null) {
                 updateVisibility();
+                adView.setLayoutParams(adParams);
                 adLayout.addView(adView);
                 if (mMediationBannerListener != null) {
                     mMediationBannerListener.onAdLoaded(VungleInterstitialAdapter.this);

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -1,3 +1,17 @@
+// Copyright 2014 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.vungle.mediation;
 
 import android.content.Context;
@@ -416,6 +430,10 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
 
         return adSizeType != null;
     }
+
+    // Copied some code from FB adapter:
+    // https://github.com/googleads/googleads-mobile-android-mediation/blob/ebce3b3ccf1c7a0cd8ecb31819c0037b8885d584/
+    // ThirdPartyAdapters/facebook/facebook/src/main/java/com/google/ads/mediation/facebook/FacebookAdapter.java#L760
 
     // Start of helper code to remove when available in SDK
     /**

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -26,6 +26,7 @@ import androidx.annotation.Keep;
 
 import static com.vungle.warren.AdConfig.AdSize.BANNER;
 import static com.vungle.warren.AdConfig.AdSize.BANNER_LEADERBOARD;
+import static com.vungle.warren.AdConfig.AdSize.BANNER_SHORT;
 import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
 
 /**
@@ -411,11 +412,16 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         Log.i(TAG, "Found closest ad size: " + closestSize.toString());
 
         int adHeight = closestSize.getHeight();
+        int adWidth = closestSize.getWidth();
 
         if (adHeight == VUNGLE_MREC.getHeight()) {
             adSizeType = VUNGLE_MREC;
         } else if (adHeight == BANNER.getHeight()) {
-            adSizeType = BANNER;
+            if (adWidth < BANNER.getWidth()) {
+                adSizeType = BANNER_SHORT;
+            } else {
+                adSizeType = BANNER;
+            }
         } else if (adHeight == BANNER_LEADERBOARD.getHeight()) {
             adSizeType = BANNER_LEADERBOARD;
         }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -337,6 +337,14 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
             vungleBannerAd = mVungleManager.getVungleBanner(mPlacementForPlay, mAdConfig.getAdSize(), mVunglePlayListener);
             if (vungleBannerAd != null) {
                 updateVisibility();
+                RelativeLayout.LayoutParams adViewParams = (RelativeLayout.LayoutParams) vungleBannerAd.getLayoutParams();
+                if (adViewParams == null) {
+                    adViewParams = new RelativeLayout.LayoutParams(
+                            RelativeLayout.LayoutParams.WRAP_CONTENT, RelativeLayout.LayoutParams.WRAP_CONTENT);
+                }
+                adViewParams.addRule(RelativeLayout.CENTER_HORIZONTAL, RelativeLayout.TRUE);
+                adViewParams.addRule(RelativeLayout.CENTER_VERTICAL, RelativeLayout.TRUE);
+                vungleBannerAd.setLayoutParams(adViewParams);
                 adLayout.addView(vungleBannerAd);
                 if (mMediationBannerListener != null) {
                     mMediationBannerListener.onAdLoaded(VungleInterstitialAdapter.this);

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -403,16 +403,11 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
     private boolean hasBannerSizeAd(Context context, AdSize adSize) {
         AdConfig.AdSize adSizeType = null;
 
-        int width = adSize.getWidth();
-        if (width < 0) {
-            float density = context.getResources().getDisplayMetrics().density;
-            width = Math.round(adSize.getWidthInPixels(context) / density);
-        }
-
-        ArrayList<AdSize> potentials = new ArrayList<>(3);
-        potentials.add(0, new AdSize(width, 50));
-        potentials.add(1, new AdSize(width, 90));
-        potentials.add(2, new AdSize(width, 250));
+        ArrayList<AdSize> potentials = new ArrayList<>(4);
+        potentials.add(0, new AdSize(300, 50));
+        potentials.add(1, new AdSize(320, 50));
+        potentials.add(2, new AdSize(728, 90));
+        potentials.add(3, new AdSize(300, 250));
         Log.i(TAG, "Potential ad sizes: " + potentials.toString());
         AdSize closestSize = findClosestSize(context, adSize, potentials);
         if (closestSize == null) {
@@ -424,16 +419,14 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         int adHeight = closestSize.getHeight();
         int adWidth = closestSize.getWidth();
 
-        if (adHeight == VUNGLE_MREC.getHeight()) {
+        if (adHeight == VUNGLE_MREC.getHeight() && adWidth == VUNGLE_MREC.getWidth()) {
             adSizeType = VUNGLE_MREC;
-        } else if (adHeight == BANNER.getHeight()) {
-            if (adWidth < BANNER.getWidth()) {
-                adSizeType = BANNER_SHORT;
-            } else {
-                adSizeType = BANNER;
-            }
-        } else if (adHeight == BANNER_LEADERBOARD.getHeight()) {
+        } else if (adHeight == BANNER.getHeight() && adWidth == BANNER.getWidth()) {
+            adSizeType = BANNER;
+        } else if (adHeight == BANNER_LEADERBOARD.getHeight() && adWidth == BANNER_LEADERBOARD.getWidth()) {
             adSizeType = BANNER_LEADERBOARD;
+        } else if (adHeight == BANNER_SHORT.getHeight() && adWidth == BANNER_SHORT.getWidth()) {
+            adSizeType = BANNER_SHORT;
         }
 
         mAdConfig.setAdSize(adSizeType);

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -246,11 +246,6 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         }
 
         adLayout = new RelativeLayout(context);
-        // Make adLayout wrapper match the requested ad size, as Vungle's ad uses MATCH_PARENT for
-        // its dimensions.
-        RelativeLayout.LayoutParams adViewLayoutParams = new RelativeLayout.LayoutParams(
-                adSize.getWidthInPixels(context), adSize.getHeightInPixels(context));
-        adLayout.setLayoutParams(adViewLayoutParams);
         VungleInitializer.getInstance().initialize(config.getAppId(),
                 context.getApplicationContext(),
                 new VungleInitializer.VungleInitializationListener() {
@@ -333,19 +328,10 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
             return;
 
         mVungleManager.cleanUpBanner(mPlacementForPlay);
-
         if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
             vungleBannerAd = mVungleManager.getVungleBanner(mPlacementForPlay, mAdConfig.getAdSize(), mVunglePlayListener);
             if (vungleBannerAd != null) {
                 updateVisibility();
-                RelativeLayout.LayoutParams adViewParams = (RelativeLayout.LayoutParams) vungleBannerAd.getLayoutParams();
-                if (adViewParams == null) {
-                    adViewParams = new RelativeLayout.LayoutParams(
-                            RelativeLayout.LayoutParams.WRAP_CONTENT, RelativeLayout.LayoutParams.WRAP_CONTENT);
-                }
-                adViewParams.addRule(RelativeLayout.CENTER_HORIZONTAL, RelativeLayout.TRUE);
-                adViewParams.addRule(RelativeLayout.CENTER_VERTICAL, RelativeLayout.TRUE);
-                vungleBannerAd.setLayoutParams(adViewParams);
                 adLayout.addView(vungleBannerAd);
                 if (mMediationBannerListener != null) {
                     mMediationBannerListener.onAdLoaded(VungleInterstitialAdapter.this);

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -349,7 +349,8 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         mVungleManager.cleanUpBanner(mPlacementForPlay);
         RelativeLayout.LayoutParams adParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.WRAP_CONTENT,
                 RelativeLayout.LayoutParams.WRAP_CONTENT);
-        adParams.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+        adParams.addRule(RelativeLayout.CENTER_HORIZONTAL, RelativeLayout.TRUE);
+        adParams.addRule(RelativeLayout.CENTER_VERTICAL, RelativeLayout.TRUE);
         if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
             vungleBannerAd = mVungleManager.getVungleBanner(mPlacementForPlay, mAdConfig.getAdSize(), mVunglePlayListener);
             if (vungleBannerAd != null) {
@@ -401,37 +402,22 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
     }
 
     private boolean hasBannerSizeAd(Context context, AdSize adSize) {
-        AdConfig.AdSize adSizeType = null;
-
-        ArrayList<AdSize> potentials = new ArrayList<>(4);
-        potentials.add(0, new AdSize(300, 50));
-        potentials.add(1, new AdSize(320, 50));
-        potentials.add(2, new AdSize(728, 90));
-        potentials.add(3, new AdSize(300, 250));
+        ArrayList<AdConfig.AdSize> potentials = new ArrayList<>(4);
+        potentials.add(0, BANNER_SHORT);
+        potentials.add(1, BANNER);
+        potentials.add(2, BANNER_LEADERBOARD);
+        potentials.add(3, VUNGLE_MREC);
         Log.i(TAG, "Potential ad sizes: " + potentials.toString());
-        AdSize closestSize = findClosestSize(context, adSize, potentials);
+        AdConfig.AdSize closestSize = findClosestSize(context, adSize, potentials);
         if (closestSize == null) {
             Log.i(TAG, "Not found closest ad size: " + adSize);
             return false;
         }
-        Log.i(TAG, "Found closest ad size: " + closestSize.toString());
+        Log.i(TAG, "Found closest ad size: " + closestSize.toString() + " for request ad size:" + adSize);
 
-        int adHeight = closestSize.getHeight();
-        int adWidth = closestSize.getWidth();
+        mAdConfig.setAdSize(closestSize);
 
-        if (adHeight == VUNGLE_MREC.getHeight() && adWidth == VUNGLE_MREC.getWidth()) {
-            adSizeType = VUNGLE_MREC;
-        } else if (adHeight == BANNER.getHeight() && adWidth == BANNER.getWidth()) {
-            adSizeType = BANNER;
-        } else if (adHeight == BANNER_LEADERBOARD.getHeight() && adWidth == BANNER_LEADERBOARD.getWidth()) {
-            adSizeType = BANNER_LEADERBOARD;
-        } else if (adHeight == BANNER_SHORT.getHeight() && adWidth == BANNER_SHORT.getWidth()) {
-            adSizeType = BANNER_SHORT;
-        }
-
-        mAdConfig.setAdSize(adSizeType);
-
-        return adSizeType != null;
+        return true;
     }
 
     // Copied some code from FB adapter:
@@ -443,8 +429,8 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
      * Find the closest supported AdSize from the list of potentials to the provided size. Returns
      * null if none are within given threshold size range.
      */
-    public static AdSize findClosestSize(
-            Context context, AdSize original, ArrayList<AdSize> potentials) {
+    private AdConfig.AdSize findClosestSize(
+            Context context, AdSize original, ArrayList<AdConfig.AdSize> potentials) {
         if (potentials == null || original == null) {
             return null;
         }
@@ -453,8 +439,8 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         int actualHeight = Math.round(original.getHeightInPixels(context) / density);
         original = new AdSize(actualWidth, actualHeight);
 
-        AdSize largestPotential = null;
-        for (AdSize potential : potentials) {
+        AdConfig.AdSize largestPotential = null;
+        for (AdConfig.AdSize potential : potentials) {
             if (isSizeInRange(original, potential)) {
                 if (largestPotential == null) {
                     largestPotential = potential;
@@ -466,7 +452,7 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         return largestPotential;
     }
 
-    private static boolean isSizeInRange(AdSize original, AdSize potential) {
+    private static boolean isSizeInRange(AdSize original, AdConfig.AdSize potential) {
         if (potential == null) {
             return false;
         }
@@ -488,7 +474,7 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         return true;
     }
 
-    private static AdSize getLargerByArea(AdSize size1, AdSize size2) {
+    private static AdConfig.AdSize getLargerByArea(AdConfig.AdSize size1, AdConfig.AdSize size2) {
         int area1 = size1.getWidth() * size1.getHeight();
         int area2 = size2.getWidth() * size2.getHeight();
         return area1 > area2 ? size1 : size2;


### PR DESCRIPTION
This PR will merge current changes in sdk6.5.x branch , into an existing upstream PR we had opened https://github.com/googleads/googleads-mobile-android-mediation/pull/212

Merging this PR into branch based on which above upstream PR exists will make sure that all the existing conversation of that PR are intact, and we just are adding an additional piece of logic for mapping of AdSizes for Smart/Adaptive Banners
Will also take care to update to our GA 6.5.2 SDK version