### PR TITLE
[AND-2715] Handle multiple requestBanner for same placement

### DIFF
--- a/ThirdPartyAdapters/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/build.gradle
@@ -15,7 +15,6 @@ buildscript {
 
 allprojects {
     repositories {
-        maven { url 'https://jitpack.io' }
         google()
         jcenter()
     }

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -36,13 +36,8 @@ android {
 }
 
 dependencies {
-    if (gradle.ext.has('dependOnVungleSdkProject') && gradle.ext.dependOnVungleSdkProject) {
-        implementation project(':vungle-android-sdk:publisher-sdk-android')
-    } else {
-        implementation ('com.github.vungle:vungle-android-sdk:6.5.2-RC4') {
-        //implementation ('com.vungle:publisher-sdk-android:6.5.1') {
-            transitive=true
-        }
+    implementation ('com.vungle:publisher-sdk-android:6.5.2') {
+        transitive=true
     }
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-ads:18.2.0'

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/AdapterParametersParser.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/AdapterParametersParser.java
@@ -29,7 +29,11 @@ class AdapterParametersParser {
             Log.e(TAG, "Vungle app ID should be specified!");
             throw new IllegalArgumentException();
         }
-        String uuid = networkExtras.getString(VungleExtrasBuilder.UUID_KEY);
+
+        String uuid = null;
+        if (networkExtras != null && networkExtras.containsKey(VungleExtrasBuilder.UUID_KEY)) {
+            uuid = networkExtras.getString(VungleExtrasBuilder.UUID_KEY);
+        }
 
         Config ret = new Config();
         ret.appId = appId;

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/AdapterParametersParser.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/AdapterParametersParser.java
@@ -10,11 +10,17 @@ class AdapterParametersParser {
     private static final String TAG = VungleManager.class.getSimpleName();
 
     static class Config {
-        String getAppId() {
+        private String appId;
+        private String requestUniqueId;
+
+        public String getAppId() {
             return appId;
         }
 
-        private String appId;
+        public String getRequestUniqueId() {
+            return requestUniqueId;
+        }
+
     }
 
     public static Config parse(Bundle networkExtras, Bundle serverParameters) throws IllegalArgumentException {
@@ -23,9 +29,11 @@ class AdapterParametersParser {
             Log.e(TAG, "Vungle app ID should be specified!");
             throw new IllegalArgumentException();
         }
+        String uuid = networkExtras.getString(VungleExtrasBuilder.UUID_KEY);
 
         Config ret = new Config();
         ret.appId = appId;
+        ret.requestUniqueId = uuid;
         return ret;
     }
 }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -35,8 +35,8 @@ class VungleBannerAdapter {
     @NonNull
     private AdConfig mAdConfig;
 
-    private AtomicBoolean mPendingRequestBanner = new AtomicBoolean(false);
-    private AtomicBoolean mIsLoading = new AtomicBoolean(true);;
+    private AtomicBoolean mIsLoading = new AtomicBoolean(true);
+    private boolean mPendingRequestBanner = false;
     private boolean mVisibility = true;
     @Nullable
     private VungleBanner mVungleBannerAd;
@@ -80,7 +80,7 @@ class VungleBannerAdapter {
 
     void requestBannerAd(@NonNull Context context, @NonNull String appId) {
         mIsLoading.set(true);
-        mPendingRequestBanner.set(true);
+        mPendingRequestBanner = true;
         VungleInitializer.getInstance().initialize(appId, context.getApplicationContext(),
                 new VungleInitializer.VungleInitializationListener() {
                     @Override
@@ -106,7 +106,7 @@ class VungleBannerAdapter {
             Log.d(TAG, "Vungle banner adapter destroy:" + this);
             mIsLoading.set(false);
             mVisibility = false;
-            mPendingRequestBanner.set(false);
+            mPendingRequestBanner = false;
             mVungleManager.removeActiveBannerAd(mPlacementId);
             if (mVungleBannerAd != null) {
                 mVungleBannerAd.destroyAd();
@@ -147,7 +147,7 @@ class VungleBannerAdapter {
             Log.d(TAG, "Ad load failed:" + VungleBannerAdapter.this);
             mIsLoading.set(false);
             mVungleManager.removeActiveBannerAd(mPlacementId);
-            if (mPendingRequestBanner.get() && mVungleListener != null) {
+            if (mPendingRequestBanner && mVungleListener != null) {
                 mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_NO_FILL);
             }
         }
@@ -156,14 +156,14 @@ class VungleBannerAdapter {
     private PlayAdCallback mAdPlayCallback = new PlayAdCallback() {
         @Override
         public void onAdStart(String placementId) {
-            if (mPendingRequestBanner.get() && mVungleListener != null) {
+            if (mPendingRequestBanner && mVungleListener != null) {
                 mVungleListener.onAdStart(placementId);
             }
         }
 
         @Override
         public void onAdEnd(String placementId, boolean completed, boolean isCTAClicked) {
-            if (mPendingRequestBanner.get() && mVungleListener != null) {
+            if (mPendingRequestBanner && mVungleListener != null) {
                 mVungleListener.onAdEnd(placementId, completed, isCTAClicked);
             }
         }
@@ -173,7 +173,7 @@ class VungleBannerAdapter {
             Log.d(TAG, "Ad play failed:" + VungleBannerAdapter.this);
             mIsLoading.set(false);
             mVungleManager.removeActiveBannerAd(mPlacementId);
-            if (mPendingRequestBanner.get() && mVungleListener != null) {
+            if (mPendingRequestBanner && mVungleListener != null) {
                 mVungleListener.onAdFail(placementId);
             }
         }
@@ -198,7 +198,7 @@ class VungleBannerAdapter {
     }
 
     private void createBanner() {
-        if (!mPendingRequestBanner.get()) {
+        if (!mPendingRequestBanner) {
             mIsLoading.set(false);
             mVungleManager.removeActiveBannerAd(mPlacementId);
             return;

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -206,8 +206,6 @@ class VungleBannerAdapter {
 
     private void createBanner() {
         if (!mPendingRequestBanner) {
-            mIsLoading.set(false);
-            mVungleManager.removeActiveBannerAd(mPlacementId);
             return;
         }
         cleanUp();

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -19,8 +19,6 @@ import com.vungle.warren.VungleBanner;
 import com.vungle.warren.VungleNativeAd;
 import com.vungle.warren.error.VungleException;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 class VungleBannerAdapter {
     private static final String TAG = VungleBannerAdapter.class.getSimpleName();
 
@@ -35,7 +33,7 @@ class VungleBannerAdapter {
     @NonNull
     private AdConfig mAdConfig;
 
-    private AtomicBoolean mIsLoading = new AtomicBoolean(true);
+    private boolean mIsLoading = false;
     private boolean mPendingRequestBanner = false;
     private boolean mVisibility = true;
     @Nullable
@@ -46,10 +44,11 @@ class VungleBannerAdapter {
     @NonNull
     private VungleManager mVungleManager;
 
-    VungleBannerAdapter(@NonNull String placementId, @Nullable String uniquePubRequestId) {
+    VungleBannerAdapter(@NonNull String placementId, @Nullable String uniquePubRequestId, @NonNull AdConfig adConfig) {
         mVungleManager = VungleManager.getInstance();
         this.mPlacementId = placementId;
         this.mUniquePubRequestId = uniquePubRequestId;
+        this.mAdConfig = adConfig;
     }
 
     @NonNull
@@ -62,26 +61,18 @@ class VungleBannerAdapter {
         return mUniquePubRequestId;
     }
 
-    boolean isLoading() {
-        return mIsLoading.get();
+    void setAdLayout(@NonNull RelativeLayout adLayout) {
+        this.mAdLayout = adLayout;
     }
 
     void setVungleListener(@Nullable VungleListener vungleListener) {
         this.mVungleListener = vungleListener;
     }
 
-    void setAdLayout(@NonNull RelativeLayout adLayout) {
-        this.mAdLayout = adLayout;
-    }
-
-    void setAdConfig(@NonNull AdConfig adConfig) {
-        this.mAdConfig = adConfig;
-    }
-
     void requestBannerAd(@NonNull Context context, @NonNull String appId) {
         Log.d(TAG, "requestBannerAd: " + this);
-        mIsLoading.set(true);
         mPendingRequestBanner = true;
+        mIsLoading = true;
         VungleInitializer.getInstance().initialize(appId, context.getApplicationContext(),
                 new VungleInitializer.VungleInitializationListener() {
                     @Override
@@ -92,7 +83,7 @@ class VungleBannerAdapter {
                     @Override
                     public void onInitializeError(String errorMessage) {
                         Log.d(TAG, "SDK init failed:" + VungleBannerAdapter.this);
-                        mIsLoading.set(false);
+                        mIsLoading = false;
                         mVungleManager.removeActiveBannerAd(mPlacementId);
                         if (mVungleListener != null) {
                             mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_INTERNAL_ERROR);
@@ -105,7 +96,7 @@ class VungleBannerAdapter {
         Log.d(TAG, "Vungle banner adapter try to destroy:" + this);
         if (adView == mAdLayout) {
             Log.d(TAG, "Vungle banner adapter destroy:" + this);
-            mIsLoading.set(false);
+            mIsLoading = false;
             mVisibility = false;
             mPendingRequestBanner = false;
             mVungleManager.removeActiveBannerAd(mPlacementId);
@@ -153,7 +144,7 @@ class VungleBannerAdapter {
         @Override
         public void onError(String id, VungleException exception) {
             Log.d(TAG, "Ad load failed:" + VungleBannerAdapter.this);
-            mIsLoading.set(false);
+            mIsLoading = false;
             mVungleManager.removeActiveBannerAd(mPlacementId);
             if (mPendingRequestBanner && mVungleListener != null) {
                 mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_NO_FILL);
@@ -179,8 +170,9 @@ class VungleBannerAdapter {
         @Override
         public void onError(String placementId, VungleException exception) {
             Log.d(TAG, "Ad play failed:" + VungleBannerAdapter.this);
-            mIsLoading.set(false);
-            mVungleManager.removeActiveBannerAd(mPlacementId);
+            if (mIsLoading) {
+                mVungleManager.removeActiveBannerAd(mPlacementId);
+            }
             if (mPendingRequestBanner && mVungleListener != null) {
                 mVungleListener.onAdFail(placementId);
             }
@@ -189,20 +181,10 @@ class VungleBannerAdapter {
 
     private void loadBanner() {
         Log.d(TAG, "loadBanner:" + this);
-        if (mVungleManager.isAdPlayable(mPlacementId, mAdConfig.getAdSize())) {
-            createBanner();
-        } else if (mVungleManager.isValidPlacement(mPlacementId)) {
-            if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
-                Banners.loadBanner(mPlacementId, mAdConfig.getAdSize(), mAdLoadCallback);
-            } else {
-                Vungle.loadAd(mPlacementId, mAdLoadCallback);
-            }
-        } else { // passed Placement Id is not what Vungle's SDK gets back after init/config
-            mIsLoading.set(false);
-            mVungleManager.removeActiveBannerAd(mPlacementId);
-            if (mVungleListener != null) {
-                mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_INVALID_REQUEST);
-            }
+        if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
+            Banners.loadBanner(mPlacementId, mAdConfig.getAdSize(), mAdLoadCallback);
+        } else {
+            Vungle.loadAd(mPlacementId, mAdLoadCallback);
         }
     }
 
@@ -212,7 +194,6 @@ class VungleBannerAdapter {
             return;
         }
         cleanUp();
-        mIsLoading.set(false);
         RelativeLayout.LayoutParams adParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.WRAP_CONTENT,
                 RelativeLayout.LayoutParams.WRAP_CONTENT);
         adParams.addRule(RelativeLayout.CENTER_HORIZONTAL, RelativeLayout.TRUE);
@@ -220,8 +201,9 @@ class VungleBannerAdapter {
         if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
             mVungleBannerAd = Banners.getBanner(mPlacementId, mAdConfig.getAdSize(), mAdPlayCallback);
             if (mVungleBannerAd != null) {
+                mIsLoading = false;
                 Log.d(TAG, "display banner:" + mVungleBannerAd.hashCode() + this);
-                mVungleManager.restoreActiveBannerAd(mPlacementId, this);
+                mVungleManager.storeActiveBannerAd(mPlacementId, this);
                 updateVisibility(mVisibility);
                 mVungleBannerAd.setLayoutParams(adParams);
                 mAdLayout.addView(mVungleBannerAd);
@@ -229,7 +211,6 @@ class VungleBannerAdapter {
                     mVungleListener.onAdAvailable();
                 }
             } else {
-                Log.d(TAG, "Can't display banner:" + this);
                 //missing resources
                 if (mVungleListener != null) {
                     mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_INTERNAL_ERROR);
@@ -240,9 +221,10 @@ class VungleBannerAdapter {
             mVungleNativeAd = Vungle.getNativeAd(mPlacementId, mAdConfig, mAdPlayCallback);
             if (mVungleNativeAd != null) {
                 adView = mVungleNativeAd.renderNativeView();
-                mVungleManager.restoreActiveBannerAd(mPlacementId, this);
+                mVungleManager.storeActiveBannerAd(mPlacementId, this);
             }
             if (adView != null) {
+                mIsLoading = false;
                 Log.d(TAG, "display MREC:" + mVungleNativeAd.hashCode() + this);
                 updateVisibility(mVisibility);
                 adView.setLayoutParams(adParams);
@@ -251,7 +233,6 @@ class VungleBannerAdapter {
                     mVungleListener.onAdAvailable();
                 }
             } else {
-                Log.d(TAG, "Can't display MREC:" + this);
                 //missing resources
                 if (mVungleListener != null) {
                     mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_INTERNAL_ERROR);
@@ -263,6 +244,6 @@ class VungleBannerAdapter {
     @NonNull
     @Override
     public String toString() {
-        return " [placementId=" + mPlacementId + " # uniqueRequestId=" + mUniquePubRequestId + "] hashcode: " + hashCode();
+        return " [placementId=" + mPlacementId + " # uniqueRequestId=" + mUniquePubRequestId + " # hashcode=" + hashCode() + "] ";
     }
 }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -108,14 +108,7 @@ class VungleBannerAdapter {
             mVisibility = false;
             mPendingRequestBanner = false;
             mVungleManager.removeActiveBannerAd(mPlacementId);
-            if (mVungleBannerAd != null) {
-                mVungleBannerAd.destroyAd();
-                mVungleBannerAd = null;
-            }
-            if (mVungleNativeAd != null) {
-                mVungleNativeAd.finishDisplayingAd();
-                mVungleNativeAd = null;
-            }
+            cleanUp();
         }
     }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -109,11 +109,20 @@ class VungleBannerAdapter {
         if (mVungleBannerAd != null) {
             Log.d(TAG, "Vungle banner adapter cleanUp: destroyAd # " + mVungleBannerAd.hashCode());
             mVungleBannerAd.destroyAd();
+            if (mVungleBannerAd.getParent() != null) {
+                Log.d(TAG, "Vungle banner adapter cleanUp: removeView");
+                ((RelativeLayout) mVungleBannerAd.getParent()).removeView(mVungleBannerAd);
+            }
             mVungleBannerAd = null;
         }
         if (mVungleNativeAd != null) {
             Log.d(TAG, "Vungle banner adapter cleanUp: finishDisplayingAd # " + mVungleNativeAd.hashCode());
             mVungleNativeAd.finishDisplayingAd();
+            View adView = mVungleNativeAd.renderNativeView();
+            if (adView != null && adView.getParent() != null) {
+                Log.d(TAG, "Vungle banner adapter cleanUp: removeView");
+                ((RelativeLayout) adView.getParent()).removeView(adView);
+            }
             mVungleNativeAd = null;
         }
     }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -1,0 +1,260 @@
+package com.vungle.mediation;
+
+import android.content.Context;
+import android.util.Log;
+import android.view.View;
+import android.widget.RelativeLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.ads.mediation.vungle.VungleInitializer;
+import com.google.android.gms.ads.AdRequest;
+import com.vungle.warren.AdConfig;
+import com.vungle.warren.Banners;
+import com.vungle.warren.LoadAdCallback;
+import com.vungle.warren.PlayAdCallback;
+import com.vungle.warren.Vungle;
+import com.vungle.warren.VungleBanner;
+import com.vungle.warren.VungleNativeAd;
+import com.vungle.warren.error.VungleException;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class VungleBannerAdapter {
+    private static final String TAG = VungleInterstitialAdapter.TAG;
+
+    @NonNull
+    private String mPlacementId;
+    @Nullable
+    private String mUniquePubRequestId;
+    @Nullable
+    private VungleListener mVungleListener;
+    @NonNull
+    private RelativeLayout mAdLayout;
+    @NonNull
+    private AdConfig mAdConfig;
+
+    private AtomicBoolean mPendingRequestBanner = new AtomicBoolean(false);
+    private AtomicBoolean mIsLoading = new AtomicBoolean(true);;
+    private boolean mVisibility = true;
+    @Nullable
+    private VungleBanner mVungleBannerAd;
+    @Nullable
+    private VungleNativeAd mVungleNativeAd;
+
+    @NonNull
+    private VungleManager mVungleManager;
+
+    VungleBannerAdapter(@NonNull String placementId, @Nullable String uniquePubRequestId) {
+        mVungleManager = VungleManager.getInstance();
+        this.mPlacementId = placementId;
+        this.mUniquePubRequestId = uniquePubRequestId;
+    }
+
+    @NonNull
+    String getPlacementId() {
+        return mPlacementId;
+    }
+
+    @Nullable
+    String getUniquePubRequestId() {
+        return mUniquePubRequestId;
+    }
+
+    boolean isLoading() {
+        return mIsLoading.get();
+    }
+
+    void setVungleListener(@Nullable VungleListener vungleListener) {
+        this.mVungleListener = vungleListener;
+    }
+
+    void setAdLayout(@NonNull RelativeLayout adLayout) {
+        this.mAdLayout = adLayout;
+    }
+
+    void setAdConfig(@NonNull AdConfig adConfig) {
+        this.mAdConfig = adConfig;
+    }
+
+    void requestBannerAd(@NonNull Context context, @NonNull String appId) {
+        mIsLoading.set(true);
+        mPendingRequestBanner.set(true);
+        VungleInitializer.getInstance().initialize(appId, context.getApplicationContext(),
+                new VungleInitializer.VungleInitializationListener() {
+                    @Override
+                    public void onInitializeSuccess() {
+                        loadBanner();
+                    }
+
+                    @Override
+                    public void onInitializeError(String errorMessage) {
+                        Log.d(TAG, "SDK init failed:" + VungleBannerAdapter.this);
+                        mIsLoading.set(false);
+                        mVungleManager.removeActiveBannerAd(mPlacementId);
+                        if (mVungleListener != null) {
+                            mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_INTERNAL_ERROR);
+                        }
+                    }
+                });
+    }
+
+    void destroy(@Nullable View adView) {
+        Log.d(TAG, "Vungle banner adapter try to destroy.");
+        if (adView == mAdLayout) {
+            Log.d(TAG, "Vungle banner adapter destroy:" + this);
+            mIsLoading.set(false);
+            mVisibility = false;
+            mPendingRequestBanner.set(false);
+            mVungleManager.removeActiveBannerAd(mPlacementId);
+            if (mVungleBannerAd != null) {
+                mVungleBannerAd.destroyAd();
+                mVungleBannerAd = null;
+            }
+            if (mVungleNativeAd != null) {
+                mVungleNativeAd.finishDisplayingAd();
+                mVungleNativeAd = null;
+            }
+        }
+    }
+
+    void preCache() {
+        if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
+            Banners.loadBanner(mPlacementId, mAdConfig.getAdSize(), null);
+        } else {
+            Vungle.loadAd(mPlacementId, null);
+        }
+    }
+
+    void updateVisibility(boolean visible) {
+        this.mVisibility = visible;
+        if (mVungleBannerAd != null) {
+            mVungleBannerAd.setAdVisibility(visible);
+        } else if (mVungleNativeAd != null) {
+            mVungleNativeAd.setAdVisibility(visible);
+        }
+    }
+
+    private LoadAdCallback mAdLoadCallback = new LoadAdCallback() {
+        @Override
+        public void onAdLoad(String id) {
+            createBanner();
+        }
+
+        @Override
+        public void onError(String id, VungleException exception) {
+            Log.d(TAG, "Ad load failed:" + VungleBannerAdapter.this);
+            mIsLoading.set(false);
+            mVungleManager.removeActiveBannerAd(mPlacementId);
+            if (mPendingRequestBanner.get() && mVungleListener != null) {
+                mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_NO_FILL);
+            }
+        }
+    };
+
+    private PlayAdCallback mAdPlayCallback = new PlayAdCallback() {
+        @Override
+        public void onAdStart(String placementId) {
+            if (mPendingRequestBanner.get() && mVungleListener != null) {
+                mVungleListener.onAdStart(placementId);
+            }
+        }
+
+        @Override
+        public void onAdEnd(String placementId, boolean completed, boolean isCTAClicked) {
+            if (mPendingRequestBanner.get() && mVungleListener != null) {
+                mVungleListener.onAdEnd(placementId, completed, isCTAClicked);
+            }
+        }
+
+        @Override
+        public void onError(String placementId, VungleException exception) {
+            Log.d(TAG, "Ad play failed:" + VungleBannerAdapter.this);
+            mIsLoading.set(false);
+            mVungleManager.removeActiveBannerAd(mPlacementId);
+            if (mPendingRequestBanner.get() && mVungleListener != null) {
+                mVungleListener.onAdFail(placementId);
+            }
+        }
+    };
+
+    private void loadBanner() {
+        if (mVungleManager.isAdPlayable(mPlacementId, mAdConfig.getAdSize())) {
+            createBanner();
+        } else if (mVungleManager.isValidPlacement(mPlacementId)) {
+            if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
+                Banners.loadBanner(mPlacementId, mAdConfig.getAdSize(), mAdLoadCallback);
+            } else {
+                Vungle.loadAd(mPlacementId, mAdLoadCallback);
+            }
+        } else { // passed Placement Id is not what Vungle's SDK gets back after init/config
+            mIsLoading.set(false);
+            mVungleManager.removeActiveBannerAd(mPlacementId);
+            if (mVungleListener != null) {
+                mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_INVALID_REQUEST);
+            }
+        }
+    }
+
+    private void createBanner() {
+        if (!mPendingRequestBanner.get()) {
+            mIsLoading.set(false);
+            mVungleManager.removeActiveBannerAd(mPlacementId);
+            return;
+        }
+        if (mVungleBannerAd != null) {
+            Log.d(TAG, "createBanner ### destroyAd");
+            mVungleBannerAd.destroyAd();
+            mVungleBannerAd = null;
+        }
+        if (mVungleNativeAd != null) {
+            Log.d(TAG, "createBanner ### finishDisplayingAd");
+            mVungleNativeAd.finishDisplayingAd();
+            mVungleNativeAd = null;
+        }
+        mIsLoading.set(false);
+        RelativeLayout.LayoutParams adParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.WRAP_CONTENT,
+                RelativeLayout.LayoutParams.WRAP_CONTENT);
+        adParams.addRule(RelativeLayout.CENTER_HORIZONTAL, RelativeLayout.TRUE);
+        adParams.addRule(RelativeLayout.CENTER_VERTICAL, RelativeLayout.TRUE);
+        if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
+            mVungleBannerAd = Banners.getBanner(mPlacementId, mAdConfig.getAdSize(), mAdPlayCallback);
+            if (mVungleBannerAd != null) {
+                updateVisibility(mVisibility);
+                mVungleBannerAd.setLayoutParams(adParams);
+                mAdLayout.addView(mVungleBannerAd);
+                if (mVungleListener != null) {
+                    mVungleListener.onAdAvailable();
+                }
+            } else {
+                //missing resources
+                if (mVungleListener != null) {
+                    mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_INTERNAL_ERROR);
+                }
+            }
+        } else {
+            mVungleNativeAd = Vungle.getNativeAd(mPlacementId, mAdConfig, mAdPlayCallback);
+            View adView = mVungleNativeAd != null ? mVungleNativeAd.renderNativeView() : null;
+            if (adView != null) {
+                updateVisibility(mVisibility);
+                adView.setLayoutParams(adParams);
+                mAdLayout.addView(adView);
+                if (mVungleListener != null) {
+                    mVungleListener.onAdAvailable();
+                }
+            } else {
+                //missing resources
+                if (mVungleListener != null) {
+                    mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_INTERNAL_ERROR);
+                }
+            }
+        }
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return " [placementId=" + mPlacementId + " # uniqueRequestId=" + mUniquePubRequestId + "] ";
+    }
+}

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -119,6 +119,20 @@ class VungleBannerAdapter {
         }
     }
 
+    void cleanUp() {
+        Log.d(TAG, "Vungle banner adapter try to cleanUp.");
+        if (mVungleBannerAd != null) {
+            Log.d(TAG, "Vungle banner adapter cleanUp: destroyAd");
+            mVungleBannerAd.destroyAd();
+            mVungleBannerAd = null;
+        }
+        if (mVungleNativeAd != null) {
+            Log.d(TAG, "Vungle banner adapter cleanUp: finishDisplayingAd");
+            mVungleNativeAd.finishDisplayingAd();
+            mVungleNativeAd = null;
+        }
+    }
+
     void preCache() {
         if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
             Banners.loadBanner(mPlacementId, mAdConfig.getAdSize(), null);
@@ -203,16 +217,7 @@ class VungleBannerAdapter {
             mVungleManager.removeActiveBannerAd(mPlacementId);
             return;
         }
-        if (mVungleBannerAd != null) {
-            Log.d(TAG, "createBanner ### destroyAd");
-            mVungleBannerAd.destroyAd();
-            mVungleBannerAd = null;
-        }
-        if (mVungleNativeAd != null) {
-            Log.d(TAG, "createBanner ### finishDisplayingAd");
-            mVungleNativeAd.finishDisplayingAd();
-            mVungleNativeAd = null;
-        }
+        cleanUp();
         mIsLoading.set(false);
         RelativeLayout.LayoutParams adParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.WRAP_CONTENT,
                 RelativeLayout.LayoutParams.WRAP_CONTENT);

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleExtrasBuilder.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleExtrasBuilder.java
@@ -4,6 +4,8 @@ import android.os.Bundle;
 
 import com.vungle.warren.AdConfig;
 
+import java.util.UUID;
+
 import androidx.annotation.Nullable;
 import androidx.annotation.Size;
 
@@ -20,11 +22,13 @@ public final class VungleExtrasBuilder {
     private static final String EXTRA_ORIENTATION = "adOrientation";
     static final String EXTRA_ALL_PLACEMENTS = "allPlacements";
     static final String EXTRA_PLAY_PLACEMENT = "playPlacement";
+    static final String UUID_KEY = "uniqueVungleRequestKey";
 
     private final Bundle mBundle = new Bundle();
 
     public VungleExtrasBuilder(@Nullable @Size(min = 1L) String[] placements) {
         mBundle.putStringArray(EXTRA_ALL_PLACEMENTS, placements);
+        mBundle.putString(UUID_KEY, UUID.randomUUID().toString());
     }
 
     public VungleExtrasBuilder setPlayingPlacement(String placement) {

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleExtrasBuilder.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleExtrasBuilder.java
@@ -72,6 +72,7 @@ public final class VungleExtrasBuilder {
 
     public static AdConfig adConfigWithNetworkExtras(Bundle networkExtras) {
         AdConfig adConfig = new AdConfig();
+        adConfig.setMuted(true); // start muted by default.
         if (networkExtras != null) {
             adConfig.setMuted(networkExtras.getBoolean(EXTRA_START_MUTED, false));
             adConfig.setFlexViewCloseTime(networkExtras.getInt(EXTRA_FLEXVIEW_CLOSE_TIME, 0));
@@ -79,9 +80,5 @@ public final class VungleExtrasBuilder {
             adConfig.setAdOrientation(networkExtras.getInt(EXTRA_ORIENTATION, AdConfig.AUTO_ROTATE));
         }
         return adConfig;
-    }
-
-    static boolean isStartMutedNotConfigured(Bundle networkExtras) {
-        return (networkExtras != null && !networkExtras.containsKey(EXTRA_START_MUTED));
     }
 }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleExtrasBuilder.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleExtrasBuilder.java
@@ -1,6 +1,7 @@
 package com.vungle.mediation;
 
 import android.os.Bundle;
+import android.text.TextUtils;
 
 import com.vungle.warren.AdConfig;
 
@@ -28,7 +29,6 @@ public final class VungleExtrasBuilder {
 
     public VungleExtrasBuilder(@Nullable @Size(min = 1L) String[] placements) {
         mBundle.putStringArray(EXTRA_ALL_PLACEMENTS, placements);
-        mBundle.putString(UUID_KEY, UUID.randomUUID().toString());
     }
 
     public VungleExtrasBuilder setPlayingPlacement(String placement) {
@@ -66,7 +66,15 @@ public final class VungleExtrasBuilder {
         return this;
     }
 
+    public VungleExtrasBuilder setBannerUniqueRequestID(String uniqueID) {
+        mBundle.putString(UUID_KEY, uniqueID);
+        return this;
+    }
+
     public Bundle build() {
+        if (TextUtils.isEmpty(mBundle.getString(UUID_KEY, null))) {
+            mBundle.putString(UUID_KEY, UUID.randomUUID().toString());
+        }
         return mBundle;
     }
 
@@ -74,7 +82,7 @@ public final class VungleExtrasBuilder {
         AdConfig adConfig = new AdConfig();
         adConfig.setMuted(true); // start muted by default.
         if (networkExtras != null) {
-            adConfig.setMuted(networkExtras.getBoolean(EXTRA_START_MUTED, false));
+            adConfig.setMuted(networkExtras.getBoolean(EXTRA_START_MUTED, true));
             adConfig.setFlexViewCloseTime(networkExtras.getInt(EXTRA_FLEXVIEW_CLOSE_TIME, 0));
             adConfig.setOrdinal(networkExtras.getInt(EXTRA_ORDINAL_VIEW_COUNT, 0));
             adConfig.setAdOrientation(networkExtras.getInt(EXTRA_ORIENTATION, AdConfig.AUTO_ROTATE));

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -246,16 +246,7 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
             return;
         }
 
-        adLayout = new RelativeLayout(context){
-            @Override
-            protected void onWindowVisibilityChanged(int visibility) {
-                super.onWindowVisibilityChanged(visibility);
-                Log.d(TAG, "onWindowVisibilityChanged:" + visibility);
-                if (mBannerRequest != null) {
-                    mBannerRequest.updateVisibility(visibility == View.VISIBLE);
-                }
-            }
-        };
+        adLayout = new RelativeLayout(context);
         // Make adLayout wrapper match the requested ad size, as Vungle's ad uses MATCH_PARENT for
         // its dimensions.
         RelativeLayout.LayoutParams adViewLayoutParams = new RelativeLayout.LayoutParams(

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -246,7 +246,16 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
             return;
         }
 
-        adLayout = new RelativeLayout(context);
+        adLayout = new RelativeLayout(context){
+            @Override
+            protected void onWindowVisibilityChanged(int visibility) {
+                super.onWindowVisibilityChanged(visibility);
+                Log.d(TAG, "onWindowVisibilityChanged:" + visibility);
+                if (mBannerRequest != null) {
+                    mBannerRequest.updateVisibility(visibility == View.VISIBLE);
+                }
+            }
+        };
         // Make adLayout wrapper match the requested ad size, as Vungle's ad uses MATCH_PARENT for
         // its dimensions.
         RelativeLayout.LayoutParams adViewLayoutParams = new RelativeLayout.LayoutParams(

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -300,10 +300,11 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         @Override
         void onAdFail(String placement) {
             Log.w(TAG, "Ad playback error Placement: " + placement + ";" + mBannerRequest);
-            if (mMediationBannerListener != null) {
-                mMediationBannerListener.onAdFailedToLoad(VungleInterstitialAdapter.this,
-                        AdRequest.ERROR_CODE_INTERNAL_ERROR);
-            }
+            // might be too late to fire onAdFailedToLoad here.
+//            if (mMediationBannerListener != null) {
+//                mMediationBannerListener.onAdFailedToLoad(VungleInterstitialAdapter.this,
+//                        AdRequest.ERROR_CODE_INTERNAL_ERROR);
+//            }
         }
 
         @Override

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -186,7 +186,7 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         pendingRequestBanner.set(false);
         if (vungleBannerAd != null) {
             vungleBannerAd.destroyAd();
-            mVungleManager.cleanUpBanner(mPlacementForPlay);
+            mVungleManager.cleanUpBanner(mPlacementForPlay, vungleBannerAd);
             vungleBannerAd = null;
         } else if (vungleNativeAd != null) {
             vungleNativeAd.finishDisplayingAd();

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -253,7 +253,7 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
                 adSize.getWidthInPixels(context), adSize.getHeightInPixels(context));
         adLayout.setLayoutParams(adViewLayoutParams);
 
-        mBannerRequest = mVungleManager.getBannerRequest(placementForPlay, config.getRequestUniqueId());
+        mBannerRequest = mVungleManager.getBannerRequest(placementForPlay, config.getRequestUniqueId(), adConfig);
         if (mBannerRequest == null) {
             //Adapter does not support multiple Banner instances playing for same placement except for Refresh
             mMediationBannerListener
@@ -262,7 +262,6 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
             return;
         }
 
-        mBannerRequest.setAdConfig(adConfig);
         mBannerRequest.setAdLayout(adLayout);
         mBannerRequest.setVungleListener(mVungleBannerListener);
         mBannerRequest.requestBannerAd(context, config.getAppId());

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -300,11 +300,10 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         @Override
         void onAdFail(String placement) {
             Log.w(TAG, "Ad playback error Placement: " + placement + ";" + mBannerRequest);
-            // might be too late to fire onAdFailedToLoad here.
-//            if (mMediationBannerListener != null) {
-//                mMediationBannerListener.onAdFailedToLoad(VungleInterstitialAdapter.this,
-//                        AdRequest.ERROR_CODE_INTERNAL_ERROR);
-//            }
+            if (mMediationBannerListener != null) {
+                mMediationBannerListener.onAdFailedToLoad(VungleInterstitialAdapter.this,
+                        AdRequest.ERROR_CODE_INTERNAL_ERROR);
+            }
         }
 
         @Override

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -300,10 +300,6 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         @Override
         void onAdFail(String placement) {
             Log.w(TAG, "Ad playback error Placement: " + placement + ";" + mBannerRequest);
-            if (mMediationBannerListener != null) {
-                mMediationBannerListener.onAdFailedToLoad(VungleInterstitialAdapter.this,
-                        AdRequest.ERROR_CODE_INTERNAL_ERROR);
-            }
         }
 
         @Override

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -48,7 +48,7 @@ import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
 public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
         MediationBannerAdapter {
 
-    static final String TAG = VungleInterstitialAdapter.class.getSimpleName();
+    private static final String TAG = VungleInterstitialAdapter.class.getSimpleName();
     private MediationInterstitialListener mMediationInterstitialListener;
     private VungleManager mVungleManager;
     private AdConfig mAdConfig;
@@ -174,7 +174,7 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
 
     @Override
     public void onDestroy() {
-        Log.d(TAG, "onDestroy");
+        Log.d(TAG, "onDestroy: "+ hashCode());
         if (mBannerRequest != null) {
             mBannerRequest.destroy(adLayout);
             mBannerRequest = null;
@@ -317,7 +317,7 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
 
     @Override
     public View getBannerView() {
-        Log.d(TAG, "getBannerView");
+        Log.d(TAG, "getBannerView # instance: "+hashCode());
         return adLayout;
     }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleListener.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleListener.java
@@ -13,5 +13,5 @@ abstract class VungleListener {
 
     void onAdAvailable() {}
 
-    void onAdFailedToLoad() {}
+    void onAdFailedToLoad(int errorCode) {}
 }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
@@ -134,6 +134,11 @@ public class VungleManager {
         VungleBannerAdapter bannerRequest = mVungleBanners.get(placementId);
         if (bannerRequest != null) {
             String activeUniqueRequestId = bannerRequest.getUniquePubRequestId();
+            if (bannerRequest.isLoading()) {
+                //Same placement: current banner is loading and new request is coming.
+                Log.d(TAG, "Does NOT seems like Refresh: activeUniqueId: " + activeUniqueRequestId + " ###  RequestId: " + requestUniqueId);
+                return null;
+            }
             if (activeUniqueRequestId != null && requestUniqueId != null) {
                 if (activeUniqueRequestId.equals(requestUniqueId)) {
                     Log.d(TAG, "Seems like Refresh: activeUniqueId: " + activeUniqueRequestId + " ###  RequestId: " + requestUniqueId);
@@ -150,12 +155,7 @@ public class VungleManager {
                 Log.d(TAG, "Does NOT seems like Refresh: activeUniqueId: null ###  RequestId: " + requestUniqueId);
                 return null;
             } else {
-                if (bannerRequest.isLoading()) {
-                    Log.d(TAG, "Does NOT seems like Refresh: activeUniqueId: null ###  RequestId: null");
-                    return null;
-                } else {
-                    Log.d(TAG, "Seems like Refresh: activeUniqueId: null ###  RequestId: null");
-                }
+                Log.d(TAG, "Seems like Refresh: activeUniqueId: null ###  RequestId: null");
             }
         } else {
             bannerRequest = new VungleBannerAdapter(placementId, requestUniqueId);

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
@@ -13,7 +13,9 @@ import com.vungle.warren.VungleBanner;
 import com.vungle.warren.VungleNativeAd;
 import com.vungle.warren.error.VungleException;
 
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -49,6 +51,7 @@ public class VungleManager {
 
     private ConcurrentHashMap<BannerRequest, VungleBanner> activeBannerAds;
     private ConcurrentHashMap<BannerRequest, VungleNativeAd> activeNativeAds;
+    private Set<String> mProgressPlacements;
 
     public static synchronized VungleManager getInstance() {
         if (sInstance == null) {
@@ -60,6 +63,20 @@ public class VungleManager {
     private VungleManager() {
         activeBannerAds = new ConcurrentHashMap<>();
         activeNativeAds = new ConcurrentHashMap<>();
+        mProgressPlacements = new CopyOnWriteArraySet<>();
+    }
+
+    void removeInProgressPlacement(String placementId) {
+        mProgressPlacements.remove(placementId);
+    }
+
+    synchronized boolean isPlacementInProgressAndSet(String placementId) {
+        if (mProgressPlacements.contains(placementId)) {
+            return true;
+        } else {
+            mProgressPlacements.add(placementId);
+            return false;
+        }
     }
 
     @Nullable

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
@@ -167,7 +167,11 @@ public class VungleManager {
     }
 
     void removeActiveBannerAd(String placementId) {
-        mVungleBanners.remove(placementId);
-        Log.d(TAG, "removeActiveBannerAd:" + placementId + "; size=" + mVungleBanners.size());
+        Log.d(TAG, "try to removeActiveBannerAd:" + placementId);
+        VungleBannerAdapter activeBannerAd = mVungleBanners.remove(placementId);
+        Log.d(TAG, "removeActiveBannerAd:" + activeBannerAd + "; size=" + mVungleBanners.size());
+        if (activeBannerAd != null) {
+            activeBannerAd.cleanUp();
+        }
     }
 }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
@@ -174,4 +174,11 @@ public class VungleManager {
             activeBannerAd.cleanUp();
         }
     }
+
+    void restoreActiveBannerAd(@NonNull String placementId, @NonNull VungleBannerAdapter instance) {
+        if (!mVungleBanners.containsKey(placementId)) {
+            Log.d(TAG, "restoreActiveBannerAd:" + placementId + " # " + instance);
+            mVungleBanners.put(placementId, instance);
+        }
+    }
 }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
@@ -120,7 +120,7 @@ public class VungleManager {
     }
 
     @Nullable
-    VungleBannerAdapter getBannerRequest(@NonNull String placementId, @Nullable String requestUniqueId, @NonNull AdConfig adConfig) {
+    synchronized VungleBannerAdapter getBannerRequest(@NonNull String placementId, @Nullable String requestUniqueId, @NonNull AdConfig adConfig) {
         VungleBannerAdapter bannerRequest = mVungleBanners.get(placementId);
         if (bannerRequest != null) {
             String activeUniqueRequestId = bannerRequest.getUniquePubRequestId();

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
@@ -228,6 +228,18 @@ public class VungleManager {
         }
     }
 
+    void cleanUpBanner(@NonNull String placementId, VungleBanner bannerAd) {
+        BannerRequest bannerRequest = activeBannerRequest(placementId);
+        VungleBanner activeBannerAd = activeBannerAds.get(bannerRequest);
+        if (activeBannerAd != null && activeBannerAd == bannerAd) {
+            //Remove ad
+            //We should do Report ad
+            Log.d(TAG, "cleanUpBanner # destroyAd");
+            activeBannerAd.destroyAd();
+            activeBannerAds.remove(bannerRequest);
+        }
+    }
+
     void cleanUpBanner(BannerRequest bannerRequest) {
 
         VungleBanner activeBannerAd = activeBannerAds.get(bannerRequest);


### PR DESCRIPTION
https://vungle.atlassian.net/browse/AND-2715
SDK has limitation to play only one Banner at any given time for the same Placement
THis change handles that limitation at adapter level, as AdMob allows multiple requests for same placement to be created simultaneously. 
The change here depends on Publishers passing a new instance of Vungles network extra ( if Pub does not pass a new instance on every new request for same Placement, then this change would not matter)
We use a generated UUID in VungleExtrasBuilder to differentiate between refresh and new request. For refresh the requestBanner passes same instance of network extras and we can use the UUID to isolate the refresh scenario.
( thanks to @alexander-gubov for this suggestion )
