### PR TITLE
[AND-2754] Implement AdMob suggestion of refresh checking.

### DIFF
--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -35,8 +35,7 @@ android {
 }
 
 dependencies {
-//    implementation ('com.vungle:publisher-sdk-android:6.5.2') {
-    implementation ('com.github.vungle:vungle-android-sdk:6.5.3-RC1') {
+    implementation ('com.vungle:publisher-sdk-android:6.5.3') {
         transitive=true
     }
     implementation 'androidx.annotation:annotation:1.1.0'

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -3,6 +3,7 @@ package com.vungle.mediation;
 import android.content.Context;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.RelativeLayout;
 
 import androidx.annotation.NonNull;
@@ -101,7 +102,7 @@ class VungleBannerAdapter {
             Log.d(TAG, "Vungle banner adapter cleanUp: destroyAd # " + mVungleBannerAd.hashCode());
             mVungleBannerAd.destroyAd();
             if (mVungleBannerAd != null && mVungleBannerAd.getParent() != null) {
-                ((RelativeLayout) mVungleBannerAd.getParent()).removeView(mVungleBannerAd);
+                ((ViewGroup) mVungleBannerAd.getParent()).removeView(mVungleBannerAd);
             }
             mVungleBannerAd = null;
         }
@@ -111,7 +112,7 @@ class VungleBannerAdapter {
             if (mVungleNativeAd != null) {
                 View adView = mVungleNativeAd.renderNativeView();
                 if (adView != null && adView.getParent() != null) {
-                    ((RelativeLayout) adView.getParent()).removeView(adView);
+                    ((ViewGroup) adView.getParent()).removeView(adView);
                 }
             }
             mVungleNativeAd = null;

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -225,7 +225,6 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
 
         String placementForPlay = mVungleManager.findPlacement(mediationExtras, serverParameters);
         Log.d(TAG, "requestBannerAd for Placement: " + placementForPlay + " ###  Adapter instance: " + this.hashCode());
-        Log.d(TAG, "requestBannerAd for Placement: " + placementForPlay + " ###  MediationAdRequest: " + mediationAdRequest.hashCode());
 
         if (TextUtils.isEmpty(placementForPlay)) {
             String message = "Failed to load ad from Vungle: Missing or Invalid Placement ID.";

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
@@ -124,10 +124,14 @@ public class VungleManager {
         VungleBannerAdapter bannerRequest = mVungleBanners.get(placementId);
         if (bannerRequest != null) {
             String activeUniqueRequestId = bannerRequest.getUniquePubRequestId();
-            if (activeUniqueRequestId != null && activeUniqueRequestId.equals(requestUniqueId) || activeUniqueRequestId == null && requestUniqueId == null) {
-                Log.d(TAG, "Seems like Refresh: activeUniqueId: " + activeUniqueRequestId + " ###  RequestId: " + requestUniqueId);
-            } else {
-                Log.d(TAG, "Does NOT seems like Refresh: activeUniqueId: " + activeUniqueRequestId + " ###  RequestId: " + requestUniqueId);
+            Log.d(TAG, "activeUniqueId: " + activeUniqueRequestId + " ###  RequestId: " + requestUniqueId);
+            if (activeUniqueRequestId == null) {
+                Log.w(TAG, "Ad already loaded for placement ID: " + placementId + ", and cannot determine if this " +
+                        "is a refresh. Set Vungle extras when making an ad request to support refresh on Vungle banner ads.");
+                return null;
+            }
+            if (!activeUniqueRequestId.equals(requestUniqueId)) {
+                Log.w(TAG, "Ad already loaded for placement ID: " + placementId);
                 return null;
             }
         } else {


### PR DESCRIPTION
Implement latest fixes requested by AdMob on upstream PR.
AdMob has asked us to assume a new request if we get AdRequest with no unique ID in case Pub did not implement our integration suggestion. AdMob does not want to allow bad experience on side of Pubs who could use concurrent AdRequests tied to same Vungle placement for Banners.