### PR TITLE
[AND-2722] Finish & clean banner instance in absence of onDestroy() call

### DIFF
--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -99,7 +99,6 @@ class VungleBannerAdapter {
   //to break view's parent-child references chain to the leaked VungleBannerAdapter in VungleManager.
   void setAdLayout(@NonNull RelativeLayout adLayout) {
     this.mAdLayout = new WeakReference<>(adLayout);
-    ;
   }
 
   void setVungleListener(@Nullable VungleListener vungleListener) {

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -246,7 +246,23 @@ public class VungleInterstitialAdapter implements MediationInterstitialAdapter,
       return;
     }
 
-    adLayout = new RelativeLayout(context);
+    adLayout = new RelativeLayout(context) {
+      @Override
+      protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        if (mBannerRequest != null) {
+          mBannerRequest.attach();
+        }
+      }
+
+      @Override
+      protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        if (mBannerRequest != null) {
+          mBannerRequest.detach();
+        }
+      }
+    };
     // Make adLayout wrapper match the requested ad size, as Vungle's ad uses MATCH_PARENT for
     // its dimensions.
     RelativeLayout.LayoutParams adViewLayoutParams = new RelativeLayout.LayoutParams(

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
@@ -9,6 +9,7 @@ import com.vungle.warren.LoadAdCallback;
 import com.vungle.warren.PlayAdCallback;
 import com.vungle.warren.Vungle;
 import com.vungle.warren.error.VungleException;
+import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -115,9 +116,26 @@ public class VungleManager {
     return Vungle.isInitialized() && Vungle.getValidPlacements().contains(placementId);
   }
 
+  /**
+   * Workaround to finish and clean {@link VungleBannerAdapter} if {@link
+   * VungleInterstitialAdapter#onDestroy()} is not called and adapter was garbage collected.
+   */
+  private void cleanLeakedBannerAdapters() {
+    for (String id : new HashSet<>(mVungleBanners.keySet())) {
+      VungleBannerAdapter banner = mVungleBanners.get(id);
+      if (banner != null && !banner.hasAdapter()) {
+        banner = mVungleBanners.remove(id);
+        if (banner != null) {
+          banner.destroy();
+        }
+      }
+    }
+  }
+
   @Nullable
   synchronized VungleBannerAdapter getBannerRequest(@NonNull String placementId,
       @Nullable String requestUniqueId, @NonNull AdConfig adConfig) {
+    cleanLeakedBannerAdapters();
     VungleBannerAdapter bannerRequest = mVungleBanners.get(placementId);
     if (bannerRequest != null) {
       String activeUniqueRequestId = bannerRequest.getUniquePubRequestId();


### PR DESCRIPTION
1) Removes referenced from Adapter and Banner request to allow the adapter to be garbage collected
2) On the next request for any Banner, leaked one (without adapter) will be destroyed.
3) master , use https://raw.githubusercontent.com/google/styleguide/gh-pages/intellij-java-google-style.xml for formatting

To reproduce - tap 5th button on Multiple banner screen while it's loading, banner got leaked until new GC happens and refresh or new AdView will be displayed after