### PR TITLE
[AND-2836] Set CCPA status at adapter level.

### DIFF
--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleConsent.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleConsent.java
@@ -32,4 +32,21 @@ public class VungleConsent {
   public static String getCurrentVungleConsentMessageVersion() {
     return sCurrentVungleConsentMessageVersion;
   }
+
+  /**
+   * Update CCPA consent status.
+   * @param status See {@link Vungle.Consent}.
+   *               If true, the user has consented to us gathering data about their device.
+   */
+  public static void setCCPAStatus(Vungle.Consent status) {
+    Vungle.updateCCPAStatus(status);
+  }
+
+  /**
+   * Whether a user has Accepted CCPA Consent.
+   * @return null if user has not called earlier with {@link VungleConsent#setCCPAStatus(Vungle.Consent)}.
+   */
+  public static Vungle.Consent getCCPAStatus() {
+    return Vungle.getCCPAStatus();
+  }
 }


### PR DESCRIPTION
In scope of EA2 or GA release , we need to use setting CCPA status similar to how we set GDPR.

We are still getting confirmation from AdMob if it will be fine to do this, in interim we want the changes to be ready.

We will have to make sure our implementation is able to set the CCPA flags for the early initialization, query/get the status, and as well as support if the status is required to be updated at any point.