### PR TITLE
[AND-2839] Remove additional callback onAdClosed

### DIFF
--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -203,7 +203,6 @@ class VungleBannerAdapter {
           VungleListener listener = getVungleListener();
           if (mPendingRequestBanner && listener != null) {
             listener.onAdEnd(placementId);
-            listener.onAdClosed(placementId);
           }
         }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -330,20 +330,15 @@ public class VungleInterstitialAdapter
 
         @Override
         void onAdEnd(String placementId) {
-          //no op
+            if (mMediationBannerListener != null) {
+                mMediationBannerListener.onAdClosed(VungleInterstitialAdapter.this);
+            }
         }
 
         @Override
         void onAdLeftApplication(String placementId) {
           if (mMediationBannerListener != null) {
             mMediationBannerListener.onAdLeftApplication(VungleInterstitialAdapter.this);
-          }
-        }
-
-        @Override
-        void onAdClosed(String placementId) {
-          if (mMediationBannerListener != null) {
-            mMediationBannerListener.onAdClosed(VungleInterstitialAdapter.this);
           }
         }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleListener.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleListener.java
@@ -14,8 +14,6 @@ abstract class VungleListener {
 
   void onAdLeftApplication(String placementId) {}
 
-  void onAdClosed(String placementId) {}
-
   void onAdStart(String placement) {}
 
   void onAdFail(String placement) {}


### PR DESCRIPTION
Based on feedback from: 
https://github.com/googleads/googleads-mobile-android-mediation/pull/258#discussion_r445737069

The additional onAdClosed is currently redundant and we can remove it from our VungleListener.
Reverting some of the changes made in: https://vungle.atlassian.net/browse/AND-2839

To fix this callback order we will have to made some changes to our SDK (To VungleBanner) so assuming our current banner callstack is fine w/ Admob we can revert these changes.

Current Callstacks:
Vungle Banner:
onAdLoaded 
— click —
onAdOpened (Click)
— back —
— click privacy — 
onAdLeftApplication (Privacy)
— back —
— exit activity — 
onAdClosed

AdMob Banner:
onAdLoaded
— click — 
onAdOpened
onAdLeftApplication
— back — 
onAdClosed
— close ad — 