### PR TITLE
[Admob] Update 6.7.x with GA 6.7.1

### DIFF
--- a/ThirdPartyAdapters/applovin/CHANGELOG.md
+++ b/ThirdPartyAdapters/applovin/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## AppLovin Android Mediation Adapter Changelog
 
+### Version 9.13.2.0
+- Verified compatibility with AppLovin SDK 9.13.2.
+- Updated the minimum required Google Mobile Ads SDK version to 19.3.0.
+
+Built and tested with:
+- Google Mobile Ads SDK version 19.3.0.
+- AppLovin SDK version 9.13.2.
+
 ### Version 9.13.1.0
 - Verified compatibility with AppLovin SDK 9.13.1.
 - Adapter now throws an error if multiple interstitial ads are requested using the same Zone ID.

--- a/ThirdPartyAdapters/applovin/applovin/build.gradle
+++ b/ThirdPartyAdapters/applovin/applovin/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "9.13.1.0"
+    stringVersion = "9.13.2.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -19,7 +19,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 28
-        versionCode 9130100
+        versionCode 9130200
         versionName stringVersion
     }
     buildTypes {
@@ -31,10 +31,10 @@ android {
 }
 
 dependencies {
-    implementation 'com.applovin:applovin-sdk:9.13.1'
+    implementation 'com.applovin:applovin-sdk:9.13.2'
 
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-ads:19.2.0'
+    implementation 'com.google.android.gms:play-services-ads:19.3.0'
 }
 
 /**

--- a/ThirdPartyAdapters/facebook/CHANGELOG.md
+++ b/ThirdPartyAdapters/facebook/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Facebook Android Mediation Adapter Changelog
 
+#### 5.11.0.0
+- Verified compatibility with Facebook SDK v5.11.0.
+
+Built and tested with:
+- Google Mobile Ads SDK version 19.2.0.
+- Facebook SDK version 5.11.0.
+
 #### 5.10.1.0
 - Verified compatibility with Facebook SDK v5.10.1.
 

--- a/ThirdPartyAdapters/facebook/facebook/build.gradle
+++ b/ThirdPartyAdapters/facebook/facebook/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "5.10.1.0"
+    stringVersion = "5.11.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -19,7 +19,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 5100100
+        versionCode 5110000
         versionName stringVersion
     }
     buildTypes {
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.facebook.android:audience-network-sdk:5.10.1'
+    implementation 'com.facebook.android:audience-network-sdk:5.11.0'
 
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-ads:19.2.0'

--- a/ThirdPartyAdapters/fyber/CHANGELOG.md
+++ b/ThirdPartyAdapters/fyber/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Fyber Android Mediation Adapter Changelog
 
+#### Next Version
+- Updated the adapter to support inline adaptive banner requests.
+- Updated the minimum required Google Mobile Ads SDK version to 19.3.0.
+
 #### Version 7.5.4.0
 - Verified compatibility with Fyber SDK 7.5.4.
 - Updated the minimum required Google Mobile Ads SDK version to 19.1.0.

--- a/ThirdPartyAdapters/fyber/fyber/build.gradle
+++ b/ThirdPartyAdapters/fyber/fyber/build.gradle
@@ -34,7 +34,7 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-ads:19.1.0'
+    implementation 'com.google.android.gms:play-services-ads:19.3.0'
 
     implementation 'com.fyber.vamp:core-sdk:7.6.0'
     implementation 'com.fyber.vamp:mraid-kit:7.6.0'

--- a/ThirdPartyAdapters/ironsource/CHANGELOG.md
+++ b/ThirdPartyAdapters/ironsource/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## IronSource Android Mediation Adapter Changelog
 
+#### Version 6.18.0.0
+- Verified compatibility with ironSource SDK version 6.18.0.
+- Updated the minimum required Google Mobile Ads SDK version to 19.3.0.
+
+Built and tested with:
+- Google Mobile Ads SDK version 19.3.0.
+- IronSource SDK version 6.18.0.
+
 #### Version 6.17.0.1
 - Added descriptive error codes and reasons for adapter load/show failures.
 - Updated the minimum required Google Mobile Ads SDK version to 19.2.0.

--- a/ThirdPartyAdapters/ironsource/ironsource/build.gradle
+++ b/ThirdPartyAdapters/ironsource/ironsource/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "6.17.0.1"
+    stringVersion = "6.18.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -20,7 +20,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 6170001
+        versionCode 6180000
         versionName stringVersion
     }
 
@@ -33,10 +33,10 @@ android {
 }
 
 dependencies {
-    implementation 'com.ironsource.sdk:mediationsdk:6.17.0'
+    implementation 'com.ironsource.sdk:mediationsdk:6.18.0'
 
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-ads:19.2.0'
+    implementation 'com.google.android.gms:play-services-ads:19.3.0'
 }
 
 /**

--- a/ThirdPartyAdapters/nend/CHANGELOG.md
+++ b/ThirdPartyAdapters/nend/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## nend Android Mediation Adapter Changelog
 
+#### Version 6.0.1.0
+- Verified compatibility with nend SDK 6.0.1.
+- Updated the minimum required Google Mobile Ads SDK version to 19.3.0.
+
+Built and tested with
+- Google Mobile Ads SDK version 19.3.0.
+- Nend SDK version 6.0.1.
+
 #### Version 6.0.0.0
 - Verified compatibility with nend SDK 6.0.0.
 - Updated minimum Android SDK version to API 19.

--- a/ThirdPartyAdapters/nend/nend/build.gradle
+++ b/ThirdPartyAdapters/nend/nend/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "6.0.0.0"
+    stringVersion = "6.0.1.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -20,7 +20,7 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 29
-        versionCode 6000000
+        versionCode 6000100
         versionName stringVersion
     }
 
@@ -34,10 +34,10 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-ads:19.2.0'
+    implementation 'com.google.android.gms:play-services-ads:19.3.0'
 
     // nendSDK
-    implementation 'net.nend.android:nend-sdk:6.0.0'
+    implementation 'net.nend.android:nend-sdk:6.0.1'
 }
 
 /**

--- a/ThirdPartyAdapters/verizonmedia/CHANGELOG.md
+++ b/ThirdPartyAdapters/verizonmedia/CHANGELOG.md
@@ -1,7 +1,14 @@
 ## Verizon Media Android Mediation Adapter Changelog
 
-#### Next Version
+#### Version 1.7.0.0
+- Support for Verizon Media SDK v1.7.0.
+- Updated the minimum required Google Mobile Ads SDK version to 19.3.0.
 - Updated the adapter to support inline adaptive banner requests.
+- Added androidx.browser:browser as a dependency per Verizon's documentation.
+
+Built and tested with:
+- Google Mobile Ads SDK version 19.3.0.
+- Verizon Media SDK 1.7.0.
 
 #### Version 1.6.0.0
 - Support for Verizon Media SDK v1.6.0.

--- a/ThirdPartyAdapters/verizonmedia/verizonmedia/build.gradle
+++ b/ThirdPartyAdapters/verizonmedia/verizonmedia/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "1.6.0.0"
+    stringVersion = "1.7.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -19,7 +19,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 28
-        versionCode 1060000
+        versionCode 1070000
         versionName stringVersion
     }
     buildTypes {
@@ -32,11 +32,11 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-ads:19.1.0'
-    implementation 'com.google.android.gms:play-services-base:17.2.1'
-    implementation ('com.verizon.ads:android-vas-standard-edition:1.6.0') {
+    implementation 'com.google.android.gms:play-services-ads:19.3.0'
+    implementation ('com.verizon.ads:android-vas-standard-edition:1.7.0') {
         exclude module: 'support-compat'
     }
+    implementation 'androidx.browser:browser:1.2.0'
 }
 
 /**

--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Vungle Android Mediation Adapter Changelog
 
-#### Version 6.7.0.0
-- Verified compatibility with Vungle SDK 6.7.0.
+#### Version 6.7.1.0
+- Verified compatibility with Vungle SDK 6.7.1.
 - Updated the adapter to support inline adaptive banner requests.
 - Interstitial and rewarded ads are now unmuted by default.
 - Interstitial ads now forward the `onAdLeftApplication()` callback when clicked.

--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 #### Version 6.7.1.0
 - Verified compatibility with Vungle SDK 6.7.1.
+- Various Bug Fixes
+- Removed Vungle#setUserLegacyID API
+- Added warning flag: On devices <=API 21, OkHttp 3.14+ does not work, use 3.12.12
+
+#### Version 6.7.0.0
+- Verified compatibility with Vungle SDK 6.7.0.
 - Updated the adapter to support inline adaptive banner requests.
 - Interstitial and rewarded ads are now unmuted by default.
 - Interstitial ads now forward the `onAdLeftApplication()` callback when clicked.

--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -3,8 +3,8 @@
 #### Version 6.7.1.0
 - Verified compatibility with Vungle SDK 6.7.1.
 - Various Bug Fixes
-- Removed Vungle#setUserLegacyID API
-- Added warning flag: On devices <=API 21, OkHttp 3.14+ does not work, use 3.12.12
+- Adapter has been tested only for up to API version 29.
+- Vungle 6.7.1 SDK has support for Android 11, and has resolved some issues in order to be used with API version 30
 
 #### Version 6.7.0.0
 - Verified compatibility with Vungle SDK 6.7.0.

--- a/ThirdPartyAdapters/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/build.gradle
@@ -17,6 +17,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/ThirdPartyAdapters/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/build.gradle
@@ -17,7 +17,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "6.7.0.0"
+    stringVersion = "6.7.1.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -23,7 +23,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 6070000
+        versionCode 6070100
         versionName stringVersion
     }
     buildTypes {
@@ -35,9 +35,14 @@ android {
 }
 
 dependencies {
-    implementation ('com.vungle:publisher-sdk-android:6.7.0') {
+    implementation ('com.github.vungle:vungle-android-sdk:6.7.1') {
         transitive=true
     }
+
+//TODO: Replace with these GA is available on bitray
+//    implementation ('com.vungle:publisher-sdk-android:6.7.1') {
+//        transitive=true
+//    }
 
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-ads:19.2.0'

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -16,7 +16,7 @@ ext {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     lintOptions {
         abortOnError false
     }

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -35,14 +35,10 @@ android {
 }
 
 dependencies {
-    implementation ('com.github.vungle:vungle-android-sdk:6.7.1') {
+
+    implementation ('com.vungle:publisher-sdk-android:6.7.1') {
         transitive=true
     }
-
-//TODO: Replace with these GA is available on bitray
-//    implementation ('com.vungle:publisher-sdk-android:6.7.1') {
-//        transitive=true
-//    }
 
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-ads:19.2.0'

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -99,12 +99,6 @@ public class VungleMediationAdapter extends Adapter
       return;
     }
 
-    if (!(context instanceof Activity)) {
-      initializationCompleteCallback.onInitializationFailed(
-          "Vungle SDK requires an Activity context to initialize.");
-      return;
-    }
-
     HashSet<String> appIDs = new HashSet<>();
     for (MediationConfiguration configuration : mediationConfigurations) {
       Bundle serverParameters = configuration.getServerParameters();
@@ -155,12 +149,6 @@ public class VungleMediationAdapter extends Adapter
       MediationAdLoadCallback<MediationRewardedAd, MediationRewardedAdCallback>
           mediationAdLoadCallback) {
     mMediationAdLoadCallback = mediationAdLoadCallback;
-
-    Context context = mediationRewardedAdConfiguration.getContext();
-    if (!(context instanceof Activity)) {
-      mediationAdLoadCallback.onFailure("Vungle SDK requires an Activity context to initialize.");
-      return;
-    }
 
     Bundle mediationExtras = mediationRewardedAdConfiguration.getMediationExtras();
     Bundle serverParameters = mediationRewardedAdConfiguration.getServerParameters();

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -1,6 +1,5 @@
 package com.google.ads.mediation.vungle;
 
-import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
@@ -149,6 +148,8 @@ public class VungleMediationAdapter extends Adapter
       MediationAdLoadCallback<MediationRewardedAd, MediationRewardedAdCallback>
           mediationAdLoadCallback) {
     mMediationAdLoadCallback = mediationAdLoadCallback;
+
+    Context context = mediationRewardedAdConfiguration.getContext();
 
     Bundle mediationExtras = mediationRewardedAdConfiguration.getMediationExtras();
     Bundle serverParameters = mediationRewardedAdConfiguration.getServerParameters();


### PR DESCRIPTION
Updated to GA 6.7.1 from Bintray

Added back in removed context from VungleMediationAdapter that Google Removed:
https://github.com/googleads/googleads-mobile-android-mediation/commit/28738e9f2b9fc446f1f95587a2135e7504c5b1a0
