### PR TITLE
Adding back missing context reference for 6.7.1

### DIFF
--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -187,7 +187,7 @@ public class VungleMediationAdapter extends Adapter
     VungleInitializer.getInstance()
         .initialize(
             appID,
-            context.getApplicationContext(),
+                mediationRewardedAdConfiguration.getContext().getApplicationContext(),
             new VungleInitializationListener() {
               @Override
               public void onInitializeSuccess() {


### PR DESCRIPTION
admob broke our VungleMediationAdapter again yesterday with:
https://raw.githubusercontent.com/googleads/googleads-mobile-android-mediation/master/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java