### PR TITLE
Updating to 6.9.0 - Mapping onAdViewed to reportImpression for Rewarded

### DIFF
--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Vungle Android Mediation Adapter Changelog
 
+#### Version 6.9.0.0
+- Verified compatibility with Vungle SDK 6.9.0.
+- Added support for OMSDK
+- Various bug fixes
+
+Built and tested with:
+- Google Mobile Ads SDK version 19.5.0.
+- Vungle SDK version 6.9.0.
+
 #### Version 6.8.1.0
 - Verified compatibility with Vungle SDK 6.8.1.
 - Updated the minimum required Google Mobile Ads SDK version to 19.5.0.

--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Verified compatibility with Vungle SDK 6.9.0.
 - Added support for OMSDK
 - Various bug fixes
+- Rewarded Ad Support for Vungle onAdViewed callback
 
 Built and tested with:
 - Google Mobile Ads SDK version 19.5.0.

--- a/ThirdPartyAdapters/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url 'https://jitpack.io' }  // For Vungle
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
@@ -17,6 +18,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url 'https://jitpack.io' }  // For Vungle
     }
 }
 

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "6.9.0.0"
+    stringVersion = "6.9.0.0-early1"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -39,8 +39,7 @@ dependencies {
 //    implementation ('com.vungle:publisher-sdk-android:6.9.0') {
 //        transitive=true
 //    }
-
-    implementation 'com.github.vungle:vungle-android-sdk:6.9.0-QA1'
+    implementation 'com.github.vungle:vungle-android-sdk:6.9.0-early1'
 
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-ads:19.5.0'

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "6.8.1.0"
+    stringVersion = "6.9.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -36,9 +36,11 @@ android {
 
 dependencies {
 
-    implementation ('com.vungle:publisher-sdk-android:6.8.1') {
-        transitive=true
-    }
+//    implementation ('com.vungle:publisher-sdk-android:6.9.0') {
+//        transitive=true
+//    }
+
+    implementation 'com.github.vungle:vungle-android-sdk:6.9.0-QA1'
 
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-ads:19.5.0'

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -253,8 +253,6 @@ public class VungleMediationAdapter extends Adapter
           public void run() {
             if (mMediationRewardedAdCallback != null) {
               mMediationRewardedAdCallback.onAdOpened();
-              mMediationRewardedAdCallback.onVideoStart();
-              mMediationRewardedAdCallback.reportAdImpression();
             }
           }
         });
@@ -337,7 +335,8 @@ public class VungleMediationAdapter extends Adapter
 
   @Override
   public void onAdViewed(String placementId) {
-    // "no-op , to be mapped to respective adapter events in future release"
+    mMediationRewardedAdCallback.reportAdImpression();
+    mMediationRewardedAdCallback.onVideoStart();
   }
 
   /**

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -53,7 +53,8 @@ public class VungleMediationAdapter extends Adapter
   @Override
   public VersionInfo getVersionInfo() {
     String versionString = BuildConfig.VERSION_NAME;
-    String[] splits = versionString.split("\\.");
+    //remove any suffixes from name
+    String[] splits = versionString.split("-")[0].split("\\.");
 
     if (splits.length >= 4) {
       int major = Integer.parseInt(splits[0]);

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -335,8 +335,8 @@ public class VungleMediationAdapter extends Adapter
 
   @Override
   public void onAdViewed(String placementId) {
-    mMediationRewardedAdCallback.reportAdImpression();
     mMediationRewardedAdCallback.onVideoStart();
+    mMediationRewardedAdCallback.reportAdImpression();
   }
 
   /**


### PR DESCRIPTION
Admob has requested that we map our onAdViewed to at least one of their adImpressions we have moved onVideoStart and reportAdImpression to our onAdStart callback. It is still possible to receive errors after onAdViewed is called but that is something we can investigate in a future ticket.

Adding OMSDK from 6.9.0