### PR TITLE
AND-3648

### DIFF
--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -82,7 +82,7 @@ public class VungleInterstitialAdapter
       return;
     }
 
-    AdapterParametersParser.Config config = AdapterParametersParser.parse(appID, serverParameters);
+    AdapterParametersParser.Config config = AdapterParametersParser.parse(appID, mediationExtras);
     // Unmute full-screen ads by default.
     mAdConfig = VungleExtrasBuilder.adConfigWithNetworkExtras(mediationExtras, false);
     VungleInitializer.getInstance()

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -242,7 +242,7 @@ public class VungleInterstitialAdapter
     mMediationBannerListener = mediationBannerListener;
     String appID = serverParameters.getString(KEY_APP_ID);
     AdapterParametersParser.Config config;
-    config = AdapterParametersParser.parse(appID, serverParameters);
+    config = AdapterParametersParser.parse(appID, mediationExtras);
 
     if (TextUtils.isEmpty(appID)) {
 


### PR DESCRIPTION
use the network params instead of server param to get the unique id

This helps fix Multiple Ads corner case in test App, where we create simultaneous Banner requests for same placement, and use unique IDs to differentiate between new request and Banner refresh for same request