### PR TITLE
[AND-3760] update admob to vungle 6.10.3

### DIFF
--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Added support for Child-Directed Setting
 - Added new Vungle API for passing COPPA Status Vungle#updateCoppaStatus(boolean status)
 
+Built and tested with:
+- Google Mobile Ads SDK version 20.4.0.
+- Vungle SDK version 6.10.3.
+
 #### Version 6.10.2.0
  - Verified compatibility with Vungle SDK 6.10.2.
  - Fixed an adapter issue by replacing parameter `serverParameters`, with `mediationExtras` to obtain Vungle network-specific parameters, when requesting Banner and Interstitial ads.

--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 #### Version 6.10.3.0
 - Verified compatibility with Vungle SDK 6.10.3.
-- Added support for Child-Directed setting (COPPA) to be pass to the Vungle SDK via new API
+- Added support for Child-Directed Setting
+- Added new Vungle API for passing COPPA Status Vungle#updateCoppaStatus(boolean status)
 
 #### Version 6.10.2.0
  - Verified compatibility with Vungle SDK 6.10.2.

--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Vungle Android Mediation Adapter Changelog
 
+#### Version 6.10.3.0
+- Verified compatibility with Vungle SDK 6.10.3.
+- Added support for Child-Directed setting (COPPA) to be pass to the Vungle SDK via new API
+
 #### Version 6.10.2.0
  - Verified compatibility with Vungle SDK 6.10.2.
  - Fixed an adapter issue by replacing parameter `serverParameters`, with `mediationExtras` to obtain Vungle network-specific parameters, when requesting Banner and Interstitial ads.

--- a/ThirdPartyAdapters/vungle/gradle/wrapper/gradle-wrapper.properties
+++ b/ThirdPartyAdapters/vungle/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 //    }
 
     implementation 'androidx.annotation:annotation:1.2.0'
-    implementation 'com.google.android.gms:play-services-ads:20.3.0'
+    implementation 'com.google.android.gms:play-services-ads:20.4.0'
 }
 
 /**

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -8,17 +8,17 @@ ext {
     // String property to store the proper name of the mediation network adapter.
     adapterName = "Vungle"
     // String property to store version name.
-    stringVersion = "6.10.2.0"
+    stringVersion = "6.10.3.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 30
-        versionCode 6100200
+        targetSdkVersion 31
+        versionCode 6100300
         versionName stringVersion
         buildConfigField("String", "ADAPTER_VERSION", "\"${stringVersion}\"")
     }
@@ -31,9 +31,14 @@ android {
 }
 
 dependencies {
-    implementation ('com.vungle:publisher-sdk-android:6.10.2') {
+
+    implementation ('com.github.vungle:vungle-android-sdk:6.10.3-RC3') {
         transitive=true
     }
+
+//    implementation ('com.vungle:publisher-sdk-android:6.10.3') {
+//        transitive=true
+//    }
 
     implementation 'androidx.annotation:annotation:1.2.0'
     implementation 'com.google.android.gms:play-services-ads:20.3.0'

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleInitializer.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleInitializer.java
@@ -5,6 +5,7 @@ import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.NonNull;
 import com.google.android.gms.ads.AdError;
+import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.RequestConfiguration;
 import com.vungle.mediation.VungleConsent;
 import com.vungle.mediation.VungleNetworkSettings;
@@ -60,9 +61,12 @@ public class VungleInitializer implements InitCallback {
             }
 
             // Pass new settings to SDK.
+            updateCoppaStatus(MobileAds.getRequestConfiguration().getTagForChildDirectedTreatment());
             Vungle.init(appId, context.getApplicationContext(), VungleInitializer.this, settings);
           }
         });
+
+    updateCoppaStatus(MobileAds.getRequestConfiguration().getTagForChildDirectedTreatment());
 
     VungleSettings vungleSettings = VungleNetworkSettings.getVungleSettings();
     Vungle.init(appId, context.getApplicationContext(), VungleInitializer.this, vungleSettings);

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleInitializer.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleInitializer.java
@@ -110,7 +110,7 @@ public class VungleInitializer implements InitCallback {
     // Unused
   }
 
-  public void updateCoppaStatus(int configuration){
+  public void updateCoppaStatus(int configuration) {
     switch (configuration) {
       case RequestConfiguration.TAG_FOR_CHILD_DIRECTED_TREATMENT_TRUE :
         Vungle.updateUserCoppaStatus(true);

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleInitializer.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleInitializer.java
@@ -5,6 +5,7 @@ import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.NonNull;
 import com.google.android.gms.ads.AdError;
+import com.google.android.gms.ads.RequestConfiguration;
 import com.vungle.mediation.VungleConsent;
 import com.vungle.mediation.VungleNetworkSettings;
 import com.vungle.warren.InitCallback;
@@ -107,6 +108,17 @@ public class VungleInitializer implements InitCallback {
   @Override
   public void onAutoCacheAdAvailable(String placementId) {
     // Unused
+  }
+
+  public void updateCoppaStatus(int configuration){
+    switch (configuration) {
+      case RequestConfiguration.TAG_FOR_CHILD_DIRECTED_TREATMENT_TRUE :
+        Vungle.updateUserCoppaStatus(true);
+        break;
+      case RequestConfiguration.TAG_FOR_CHILD_DIRECTED_TREATMENT_FALSE :
+        Vungle.updateUserCoppaStatus(false);
+        break;
+    }
   }
 
   public interface VungleInitializationListener {

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -270,6 +270,10 @@ public class VungleMediationAdapter extends Adapter
 
     // Unmute full-screen ads by default.
     mAdConfig = VungleExtrasBuilder.adConfigWithNetworkExtras(mediationExtras, false);
+
+    VungleInitializer.getInstance()
+            .updateCoppaStatus(mediationRewardedAdConfiguration.taggedForChildDirectedTreatment());
+
     VungleInitializer.getInstance()
         .initialize(
             appID,

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -71,6 +71,9 @@ public class VungleInterstitialAdapter
       return;
     }
 
+    VungleInitializer.getInstance()
+            .updateCoppaStatus(mediationAdRequest.taggedForChildDirectedTreatment());
+
     mMediationInterstitialListener = mediationInterstitialListener;
     mVungleManager = VungleManager.getInstance();
     mPlacementForPlay = mVungleManager.findPlacement(mediationExtras, serverParameters);
@@ -255,6 +258,10 @@ public class VungleInterstitialAdapter
       }
       return;
     }
+
+    VungleInitializer.getInstance()
+            .updateCoppaStatus(mediationAdRequest.taggedForChildDirectedTreatment());
+
     mVungleManager = VungleManager.getInstance();
 
     String placementForPlay = mVungleManager.findPlacement(mediationExtras, serverParameters);


### PR DESCRIPTION
Closed on PR:
https://github.com/Vungle/googleads-mobile-android-mediation/pull/111/files

6.10.3 Changes based off master.

1) Updated to 6.10.3
2) If coppa in admob adapter is set, we will use that value