### PR TITLE
[AND-4718] This commit removes the impression recording override so bidding native ads will receive the impression callback.

### DIFF
--- a/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/src/main/java/com/google/ads/mediation/vungle/rtb/VungleRtbNativeAd.java
+++ b/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/src/main/java/com/google/ads/mediation/vungle/rtb/VungleRtbNativeAd.java
@@ -257,7 +257,6 @@ public class VungleRtbNativeAd extends UnifiedNativeAdMapper implements NativeAd
       setIcon(new VungleNativeMappedImage(Uri.parse(iconUrl)));
     }
 
-    setOverrideImpressionRecording(true);
     setOverrideClickHandling(true);
   }
 


### PR DESCRIPTION
This commit removes the impression recording override so bidding native ads will receive the impression callback.

AND-4718